### PR TITLE
GPU code fix

### DIFF
--- a/layers/MaskedLoss.lua
+++ b/layers/MaskedLoss.lua
@@ -41,7 +41,7 @@ end
 
 function MaskedLoss:updateGradInput(input)
   local input, target = unpack(input)
-  local gradInput = torch.Tensor(input:size()):fill(0)
+  local gradInput = input.new(input:size()):fill(0)
   local z = -1 / target:size(1)
   for i=1,target:size(1) do
     if target[i] ~= 0 then

--- a/layers/MaskedLoss.lua
+++ b/layers/MaskedLoss.lua
@@ -41,14 +41,13 @@ end
 
 function MaskedLoss:updateGradInput(input)
   local input, target = unpack(input)
-  self.gradInput:resizeAs(input)
-  self.gradInput:zero()
+  local gradInput = torch.Tensor(input:size()):fill(0)
   local z = -1 / target:size(1)
-  local gradInput = self.gradInput
   for i=1,target:size(1) do
     if target[i] ~= 0 then
       gradInput[i][target[i]] = z
     end
   end
+  self.gradInput = {gradInput, torch.Tensor({0}), torch.Tensor({0})}
   return self.gradInput
 end

--- a/main.lua
+++ b/main.lua
@@ -61,9 +61,10 @@ function create_network()
                                       {err, nn.Identity()(next_s)})
   module:getParameters():uniform(-params.init_weight, params.init_weight)
   if params.gpuidx > 0 then
-    module:cuda()
+    return module:cuda()
+  else
+    return module
   end
-  return module
 end
 
 function setup()
@@ -79,7 +80,7 @@ function setup()
     for d = 1, 2 * params.layers do
       model.s[j][d] = torch.zeros(params.batch_size, params.rnn_size)
       if params.gpuidx > 0 then
-        model.s[j][d]:cuda()
+        model.s[j][d] = model.s[j][d]:cuda()
       end
 
     end
@@ -88,8 +89,8 @@ function setup()
     model.start_s[d] = torch.zeros(params.batch_size, params.rnn_size)
     model.ds[d] = torch.zeros(params.batch_size, params.rnn_size)
     if params.gpuidx > 0 then
-      model.start_s[d]:cuda()
-      model.ds[d]:cuda()
+      model.start_s[d] = model.start_s[d]:cuda()
+      model.ds[d] = model.ds[d]:cuda()
     end
   end
   model.core_network = core_network

--- a/main.lua
+++ b/main.lua
@@ -250,20 +250,20 @@ function main()
 
   init_gpu(opt.gpuidx)
   state_train = {hardness=_G[opt.strategy],
-    len=math.min(1001, params.seq_length + 1),
+    len=math.max(1001, params.seq_length + 1),
     seed=1,
     kind=0,
     batch_size=params.batch_size,
     name="Training" }
   state_val =   {hardness=current_hardness,
-    len=math.min(501, params.seq_length + 1),
+    len=math.max(501, params.seq_length + 1),
     seed=1,
     kind=1,
     batch_size=params.batch_size,
     name="Validation" }
 
   state_test =  {hardness=target_hardness,
-    len=math.min(501, params.seq_length + 1),
+    len=math.max(501, params.seq_length + 1),
     seed=1,
     kind=2,
     batch_size=params.batch_size,

--- a/main.lua
+++ b/main.lua
@@ -250,7 +250,7 @@ function main()
 
   init_gpu(opt.gpuidx)
   state_train = {hardness=_G[opt.strategy],
-    len=math.max(1001, params.seq_length + 1),
+    len=math.max(10001, params.seq_length + 1),
     seed=1,
     kind=0,
     batch_size=params.batch_size,


### PR DESCRIPTION
The Masked Loss returns three things as output, where as the gradInput was returning only the useful part which is gradient with respect to loss. Which is fine since we don't care about the gradients of the remaining two outputs. However, internally, nn module will seek the index one of the gradInput and pass it on to the previous layer which is LogSoftMax in the architecture. Since self.gradInput for MaskedLoss is a tensor, this will actually pass only the first row to the gradOutput in the LogSoftMax ( which I verified by logging the gradOutput of LogSoftMax), the result is that only the gradient with respect to the first element of the batch is used for training, which is obviously incorrect. The fix was simple but I believe it should have huge repercussions in terms of results in the original paper as well as the conclusions drawn.